### PR TITLE
Region of attraction estimation under constraints and/or control synthesis

### DIFF
--- a/conroaoptions.m
+++ b/conroaoptions.m
@@ -34,6 +34,9 @@ properties
     c;
     u;
     zg;
+    
+    zK;
+    Kin;
 end
 
 methods

--- a/conroaoptions.m
+++ b/conroaoptions.m
@@ -48,7 +48,9 @@ methods
         
         opt@roaoptions(f, x, varargin{:});
         
-        opt.u = u;
+        if isempty(opt.u)
+            opt.u = u;
+        end
 
         % set zg to default only if constraint is given
         if isempty(opt.c)

--- a/conroaoptions.m
+++ b/conroaoptions.m
@@ -57,6 +57,11 @@ methods
         if isempty(opt.u)
             opt.u = u;
         end
+        
+        if ~isempty(intersect(opt.x.varname, opt.u.varname))
+            warning('x and u should be disjunct.');
+        end
+        %TODO: check f is linear in u if zK is given.
 
         % set zg to default only if constraint is given
         if isempty(opt.c)

--- a/conroaoptions.m
+++ b/conroaoptions.m
@@ -1,0 +1,69 @@
+classdef conroaoptions < roaoptions
+% Options for ROA estimation under constraint control.
+%
+%% Usage & description
+%
+%   opts = conroaoptions(f, g, x, ...)
+%
+% with inputs
+%       -f: polynomial vector field
+%       -x: state-space vector as PVAR
+%       -u: input vector as PVAR
+%
+%   Name, Value:
+%       -c: constraint polynomial, vector field
+%       -zg: Monomials for constraint multiplier; zg is a column vector of
+%            monomials used to specifiy sg(x) in the Gram matrix form.
+%            [default = monomials(x, 1:2)]
+%
+%% About
+%
+% * Author:     Torbjoern Cunis
+% * Email:      <mailto:torbjoern.cunis@onera.fr>
+% * Created:    2018-12-01
+% * Changed:    2018-12-01
+%
+%% See also
+%
+% See ROAOPTIONS
+%%
+
+properties
+    %f -- inherited from ROAOPTIONS
+    %x -- inherited from ROAOPTIONS
+    c;
+    u;
+    zg;
+end
+
+methods
+    function opt = conroaoptions(f, x, u, varargin)
+        if nargin < 4 || ischar(u)
+            varargin = [{u} varargin];
+            u = [];
+        end
+        
+        opt@roaoptions(f, x, varargin{:});
+        
+        opt.u = u;
+
+        if isempty(opt.zg)
+            opt.zg = monomials(opt.x, 0:2);
+        end
+    end
+    
+    function opt = set.c(opt,value)
+        if isa(c,'polynomial')
+            opt.c = value;
+        end
+    
+    function opt = set.zg(opt,value)
+        if ismonom(value)
+            opt.zg = value;
+        else
+            error('zg must be vector of monomials.');
+        end
+    end
+end
+
+end

--- a/conroaoptions.m
+++ b/conroaoptions.m
@@ -50,18 +50,28 @@ methods
         
         opt.u = u;
 
-        if isempty(opt.zg)
+        % set zg to default only if constraint is given
+        if isempty(opt.c)
+            opt.c = polynomial(-1);
+            %opt.zg = [];
+        elseif isempty(opt.zg)
             opt.zg = monomials(opt.x, 0:2);
         end
+
     end
     
     function opt = set.c(opt,value)
-        if isa(c,'polynomial')
+        if isa(value,'polynomial')
             opt.c = value;
+        else
+            error('Constraint function must be polynomial.');
         end
+    end
     
     function opt = set.zg(opt,value)
-        if ismonom(value)
+        if isempty(value)
+            opt.zg = [];
+        elseif ismonom(value)
             opt.zg = value;
         else
             error('zg must be vector of monomials.');

--- a/conroaoptions.m
+++ b/conroaoptions.m
@@ -3,7 +3,7 @@ classdef conroaoptions < roaoptions
 %
 %% Usage & description
 %
-%   opts = conroaoptions(f, g, x, ...)
+%   opts = conroaoptions(f, g, x, [u], ...)
 %
 % with inputs
 %       -f: polynomial vector field
@@ -11,17 +11,21 @@ classdef conroaoptions < roaoptions
 %       -u: input vector as PVAR
 %
 %   Name, Value:
-%       -c: constraint polynomial, vector field
+%       -zK: Vector of monomials for control function;
+%            i.e., zK is a column vector of monomials used to specifiy K(x)
+%            in the vector form, K(x) = C'*zK(x).
+%       -c:  constraint polynomial, vector field
 %       -zg: Monomials for constraint multiplier; zg is a column vector of
 %            monomials used to specifiy sg(x) in the Gram matrix form.
 %            [default = monomials(x, 1:2)]
+%       -Kin: Initial control function; default: [].
 %
 %% About
 %
 % * Author:     Torbjoern Cunis
 % * Email:      <mailto:torbjoern.cunis@onera.fr>
 % * Created:    2018-12-01
-% * Changed:    2018-12-01
+% * Changed:    2019-01-15
 %
 %% See also
 %
@@ -41,7 +45,9 @@ end
 
 methods
     function opt = conroaoptions(f, x, u, varargin)
-        if nargin < 4 || ischar(u)
+        if nargin < 3
+            u = [];
+        elseif ischar(u)
             varargin = [{u} varargin];
             u = [];
         end

--- a/conroavstep.m
+++ b/conroavstep.m
@@ -53,23 +53,24 @@ end
 
 % Constraint 1: 
 % V-L1  in SOS
-sosconstr = polyconstr;
-sosconstr(1) = V >= L1;
+sosconstr = cell(4,1);
+sosconstr{1} = V >= L1;
 
 % Constraint 2: 
 % {x: p(x) <= b} is contained in {x: V(x) <= g}
-sosconstr(2) = (V-gamma) <= s1*(p-beta);
+sosconstr{2} = (V-gamma) <= s1*(p-beta);
 
 % Constraint 3:
 % {x: V(x) <= g} is contained in {x: grad(V)*f < 0}
 Vdot = jacobian(V,x)*f;
-sosconstr(3) = Vdot <= -L2 + s2*(V-gamma);
+sosconstr{3} = Vdot <= -L2 + s2*(V-gamma);
 
 % Constraint 4:
 % {x: V(x) <= g} is contained in {x: c(x) <= 0}
-sosconstr(4) = -(con + sg*(gamma-V)) >= 0;
+sosconstr{4} = -(con + sg*(gamma-V)) >= 0;
 
 % Solve feasibility problem
+sosconstr = vertcat(sosconstr{:});
 [info,dopt] = sosopt(sosconstr,x,opts);
 
 % Create output

--- a/conroavstep.m
+++ b/conroavstep.m
@@ -1,0 +1,83 @@
+function [V,c] = conroavstep(f,con,p,x,z,beta,gamma,s1,s2,sg,L1,L2,opts)
+% Solves the V-s step of the piecewise ROA iteration.
+%
+%% Usage & description
+%
+%   [V,c] = conroavstep(f,c,p,x,z,beta,gamma,s1,s2,sg)
+%   [...] = conroavstep(...,L1,L2,opts)
+%
+% Solves for a Lyapunov function V which satisfies the SOS constraints 
+% while holding all other variables fixed.
+%
+% Inputs:
+%       -f:   polynomial vector field
+%       -con: constraint function (scalar polynomial)
+%       -p:   shape function (scalar polynomial)
+%       -x:   state-space vector as PVAR
+%       -z:   Nz-by-1 column vector of monomials; specifies the Lyapunov
+%             function decision variable in the vector form V(x) = c'*z(x).
+%       -beta:     level set of shape function
+%       -gamma:    level set of Lyapunov function
+%       -s1,s2,sg: set containment multipliers
+%       -L1:  epsilon 1 (double or scalar field); enforces strict positive 
+%             definiteness of the Lyapunov function.
+%       -L2:  epsilon 2 (double or scalar field); enforces strict negative 
+%             definiteness of the Lyapunov gradient.
+%       -opts:     SOS options structure;  see SOSOPTIONS.
+%
+% Outputs:
+%       -V: Lyapunov function satisfying the SOS constraints; will be empty
+%           if no feasible solution is found.
+%       -c: Nz-by-1 vector of coefficients of the returned Lyapunov
+%           function.
+%
+%% About
+%
+% * Author:     Torbjoern Cunis
+% * Email:      <mailto:torbjoern.cunis@onera.fr>
+% * Created:    2019-01-21
+% * Changed:    2019-01-21
+%
+%% See also
+%
+% See PWROAEST, ROAVSTEP
+%%
+
+if isempty(opts)
+    opts = sosoptions;
+end
+
+
+% Create Lyapunov decision variable
+[V,c] = polydecvar('c',z);
+
+% Constraint 1: 
+% V-L1  in SOS
+sosconstr = polyconstr;
+sosconstr(1) = V >= L1;
+
+% Constraint 2: 
+% {x: p(x) <= b} is contained in {x: V(x) <= g}
+sosconstr(2) = (V-gamma) <= s1*(p-beta);
+
+% Constraint 3:
+% {x: V(x) <= g} is contained in {x: grad(V)*f < 0}
+Vdot = jacobian(V,x)*f;
+sosconstr(3) = Vdot <= -L2 + s2*(V-gamma);
+
+% Constraint 4:
+% {x: V(x) <= g} is contained in {x: c(x) <= 0}
+sosconstr(4) = -(con + sg*(gamma-V)) >= 0;
+
+% Solve feasibility problem
+[info,dopt] = sosopt(sosconstr,x,opts);
+
+% Create output
+if info.feas
+    V = subs(V,dopt);
+    c = subs(c,dopt);
+else
+    V=[];
+    c=[];
+end
+

--- a/droaoptions.m
+++ b/droaoptions.m
@@ -1,4 +1,4 @@
-classdef droaoptions < roaoptions
+classdef droaoptions < roaoptions2
 % Options for discrete ROA estimation.
 %
 %% Usage & description
@@ -20,7 +20,7 @@ classdef droaoptions < roaoptions
 % * Author:     Torbjoern Cunis
 % * Email:      <mailto:torbjoern.cunis@onera.fr>
 % * Created:    2018-05-22
-% * Changed:    2018-09-09
+% * Changed:    2018-10-28
 %
 %% See also
 %
@@ -35,7 +35,7 @@ end
 
 methods
     function opt = droaoptions(varargin)
-        opt@roaoptions(varargin{:});
+        opt@roaoptions2(varargin{:});
         
         if isempty(opt.tau)
             opt.tau = 0;

--- a/p2sym.m
+++ b/p2sym.m
@@ -1,0 +1,44 @@
+function s=p2sym(p)
+% function s=p2s(p)
+%
+% DESCRIPTION 
+%   Converts from a multipoly polynomial to a symbolic toolbox polynomial.
+%   
+% INPUTS 
+%   p: Polynomial created using the multipoly toolbox
+%
+% OUTPUTS  
+%   s: Polynomial created using the symbolic toolbox  
+%  
+% SYNTAX 
+%   s = p2s(p)
+%
+% See also s2p
+  
+% 1/30/2003  PJS  Initial Coding  
+% 11/23/2010 PJS  Updated for matrix polynomials
+
+
+% Get polynomial info
+[nr nc] = size(p);
+[nt,nv] = size(p.degmat);
+coef = p.coefficient;
+deg = p.degmat;
+var = p.varname;
+
+% Create symbolic toolbox variables
+for i1 = 1:nv
+    eval([var{i1} '= sym(''' var{i1} ''', ''real'');']);
+end
+
+% Construct monomial by monomial
+s = zeros(nr,nc);
+for i1 = 1:nt
+    termexp = deg(i1,:);
+    idx = find(termexp);
+    term = 1;
+    for i2 = 1:length(idx)
+        eval(['term = term*(' var{idx(i2)} ')^termexp(idx(i2));']);
+    end
+    s = s + reshape(coef(i1,:),[nr,nc])*term;
+end  

--- a/pcontain.m
+++ b/pcontain.m
@@ -145,10 +145,18 @@ end
 %     (p2*s-p1) + t*s in SOS
 t = pvar('g');
 
-s = sosdecvar2('c',z);
+if size(p1,1) == size(p2,1)
+    s = sosdecvar2('c',z);
+else
+    s = sosmdecvar('c',z,size(p1,1)/size(p2,1));
+end
 
-sosc(1) = s>=0;
-sosc(2) = (p2*s-p1)+t*s>=0;
+sosc = cell(2,1);
+
+sosc{1} = s>=0;
+sosc{2} = (p2*s-p1)+t*s >= 0;
+
+sosc = vertcat(sosc{:});
 
 gopts = opts;
 gopts.minobj = -opts.maxobj;

--- a/private/sosmdecvar.m
+++ b/private/sosmdecvar.m
@@ -1,0 +1,9 @@
+function s = sosmdecvar(cstr, z, k)
+% Returns k-by-1 vector of SOS decision variables.
+
+s = polynomial(zeros(k,1));
+for i=1:k
+    s(i) = sosdecvar(sprintf('%s__%d',cstr,i), z);
+end
+
+end

--- a/pwpcontain.m
+++ b/pwpcontain.m
@@ -55,13 +55,23 @@ end
 %       s, si in SOS
 %       p2*s - pa + t*s + phi*si in SOS
 t   = pvar('g');
-s1  = sosdecvar2('c',z);
-si1 = sosdecvar2('ci',zi);
 
-sosc(1) = s1 >= 0;
-sosc(2) = si1 >= 0;
+if size(pa,1) == size(p2,1)
+    s1  = sosdecvar2('c',z);
+    si1 = sosdecvar2('ci',zi);
+else
+    s1  = sosmdecvar('c',z,size(pa,1)/size(p2,1));
+    si1 = sosmdecvar('ci',zi,size(pa,1)/size(p2,1));
+end
 
-sosc(3) = (p2*s1 - pa) + t*s1 +  phi   *si1 >= 0;
+sosc = cell(3,1);
+
+sosc{1} = s1 >= 0;
+sosc{2} = si1 >= 0;
+
+sosc{3} = (p2*s1 - pa) + t*s1 +  phi   *si1 >= 0;
+
+sosc = vertcat(sosc{:});
 
 gopts = opts;
 gopts.minobj = -opts.maxobj;

--- a/pwroaKstep.m
+++ b/pwroaKstep.m
@@ -1,6 +1,130 @@
-function [K,cK] = pwroaKstep(f1,f2,phi,p,c,x,u,zK,V,beta,gamma,s0,s,si,sg,sj,L1,L2,roaopts)
+function [K,c] = pwroaKstep(f1,f2,phi,con,~,x,u,z,V,~,gamma,~,s,si,sg,sj,~,L2,roaopts)
 % Solves the K-V-s step of the constraint-piecewise ROA iteration.
+%
+%% Usage & description
+%
+%   [K,c] = pwroavstep(f1,f2,phi,con,p,x,u,z,V,beta,gamma,s1,s2,si,sg,sj)
+%   [...] = pwroavstep(...,L1,L2,opts)
+%
+% Solves for a common control function K which satisfies the SOS
+% constraints while holding all other variables fixed.
+%
+% Inputs:
+%       -f1:  first polynomial vector field
+%       -f2:  second polynomial vector field
+%       -phi: boundary condition (scalar field)
+%       -con: constraint function (scalar polynomial)
+%       -p:   shape function (scalar field)
+%       -x:   state-space vector as PVAR
+%       -u:   input vector as PVAR
+%       -z:   Nz-by-1 column vector of monomials; specifies the Lyapunov
+%             function decision variable in the vector form V(x) = c'*z(x).
+%       -V:   Lyapunov function (scalar polynomial)
+%       -beta:  level set of shape function
+%       -gamma: level set of the Lyapunov function
+%       -s1:  multiplier for beta-step; in the multiple V-step, 
+%             multipliers [s1'; s2"].
+%       -s2:  multipliers [s2'; s2"] for gamma-step (Lyapunov gradient)
+%       -si:  multipliers [si'; si"] for gamma-step (boundary condition)
+%       -sg:  multiplier for constraint step; in the multiple V-step,
+%             multipliers [sg'; sg"] (Lyapunov gradient)
+%       -sj:  multipliers [sj'; sj"] for constraint step (boundary
+%             condition) in the multiple V-step.
+%       -L1:  epsilon 1 (double or scalar field); enforces strict positive 
+%             definiteness of the Lyapunov function.
+%       -L2:  epsilon 2 (double or scalar field); enforces strict negative
+%             definiteness of the Lyapunov gradients.
+%       -opts:  SOS options structre; see SOSOPTIONS.
+%
+% Outputs:
+%       -K: control function satisfying the SOS constraints; will be empty
+%           if no feasible solution is found.
+%       -c: Nz-by-1 vector of coefficients of the returned Lyapunov
+%           function.
+%
+%% About
+%
+% * Author:     Torbjoern Cunis
+% * Email:      <mailto:torbjoern.cunis@onera.fr>
+% * Created:    2018-05-23
+% * Changed:    2019-01-21
+%
+%% See also
+%
+% See PWROAEST, ROAVSTEP
+%%
 
-error('Piecewise K-V-s step not implemented yet.')
+if isa(roaopts,'roaoptions')
+    opts = roaopts.sosopts;
+else
+    opts = roaopts;
+end
+
+% control decision variable
+[K,c] = polydecvar('c',z);
+
+% control system
+fK1 = subs(f1,u,K);
+fK2 = subs(f2,u,K);
+
+% control input constraint
+cK = subs(con,u,K);
+
+
+if length(V) == 1
+    % common Lyapunov function
+    V = V{1};
+    
+    %% Common K-V-s feasibility problem
+    sosconstr = polyconstr;
+
+    % {x: V(x) <= g} is contained in {x: grad(V)*f < 0}
+    gradV = jacobian(V,x);
+
+    % -( pa + (g-p2)*s - phi*si ) in SOS
+    sosconstr(1) = -(gradV*fK1 + L2 + s(1)*(gamma-V) - si(1)*phi) >= 0;
+    % -( pb + (g-p2)*s + (phi-l)*si ) in SOS
+    sosconstr(2) = -(gradV*fK2 + L2 + s(2)*(gamma-V) + si(2)*(phi-L2)) >= 0;
+
+    % {x: V(x) <= g} is contained in {x: c(x) <= 0}
+    sosconstr(3) = -(cK + sg*(gamma-V)) >= 0;
+
+    % solve problem
+    [info,dopt] = sosopt(sosconstr,x,opts);
+    
+else
+    % multiple Lyapunov functions
+    V1 = V{1};
+    V2 = V{2};
+    
+    %% Multiple K-V-s feasibility problem
+    sosconstr = polyconstr;
+    
+    % {x: V(x) <= g} is contained in {x: grad(V)*f < 0}
+    gradV1 = jacobian(V1,x);
+    gradV2 = jacobian(V2,x);
+    % -( pa + (g-p2)*s - phi*si ) in SOS
+    sosconstr(1) = -(gradV1*fK1 + L2 + s(1)*(gamma-V1) - si(1)*phi) >= 0;
+    % -( pb + (g-p2)*s + (phi-l)*si ) in SOS
+    sosconstr(2) = -(gradV2*fK2 + L2 + s(2)*(gamma-V2) + si(2)*(phi-L2)) >= 0;
+    
+    % {x: V1(x) <= g} intersects {x: phi(x) <= 0} is contained in {x: c(x) <= 0}
+    sosconstr(3) = -(cK + sg(1)*(gamma - V1) - sj(1)*phi) >= 0;
+    % {x: V2(x) <= g} intersects {x: phi(x) > 0} is contained in {x: c(x) <= 0}
+    sosconstr(4) = -(cK + sg(2)*(gamma - V2) + sj(2)*(phi-L2)) >= 0;
+    
+    % solve problem
+    [info,dopt] = sosopt(sosconstr,x,opts);
+    
+end
+
+%% Output
+if info.feas
+    K = subs(K,dopt);
+    c = subs(c,dopt);
+else
+    K=[];
+    c=[];
+end
 
 end

--- a/pwroaKstep.m
+++ b/pwroaKstep.m
@@ -76,20 +76,21 @@ if length(V) == 1
     V = V{1};
     
     %% Common K-V-s feasibility problem
-    sosconstr = polyconstr;
+    sosconstr = cell(3,1);
 
     % {x: V(x) <= g} is contained in {x: grad(V)*f < 0}
     gradV = jacobian(V,x);
 
     % -( pa + (g-p2)*s - phi*si ) in SOS
-    sosconstr(1) = -(gradV*fK1 + L2 + s(1)*(gamma-V) - si(1)*phi) >= 0;
+    sosconstr{1} = -(gradV*fK1 + L2 + s(1)*(gamma-V) - si(1)*phi) >= 0;
     % -( pb + (g-p2)*s + (phi-l)*si ) in SOS
-    sosconstr(2) = -(gradV*fK2 + L2 + s(2)*(gamma-V) + si(2)*(phi-L2)) >= 0;
+    sosconstr{2} = -(gradV*fK2 + L2 + s(2)*(gamma-V) + si(2)*(phi-L2)) >= 0;
 
     % {x: V(x) <= g} is contained in {x: c(x) <= 0}
-    sosconstr(3) = -(cK + sg*(gamma-V)) >= 0;
+    sosconstr{3} = -(cK + sg*(gamma-V)) >= 0;
 
     % solve problem
+    sosconstr = vertcat(sosconstr{:});
     [info,dopt] = sosopt(sosconstr,x,opts);
     
 else

--- a/pwroaKstep.m
+++ b/pwroaKstep.m
@@ -1,0 +1,6 @@
+function [K,cK] = pwroaKstep(f1,f2,phi,p,c,x,u,zK,V,beta,gamma,s0,s,si,sg,sj,L1,L2,roaopts)
+% Solves the K-V-s step of the constraint-piecewise ROA iteration.
+
+error('Piecewise K-V-s step not implemented yet.')
+
+end

--- a/pwroaKstep.m
+++ b/pwroaKstep.m
@@ -99,22 +99,23 @@ else
     V2 = V{2};
     
     %% Multiple K-V-s feasibility problem
-    sosconstr = polyconstr;
+    sosconstr = cell(4,1);
     
     % {x: V(x) <= g} is contained in {x: grad(V)*f < 0}
     gradV1 = jacobian(V1,x);
     gradV2 = jacobian(V2,x);
     % -( pa + (g-p2)*s - phi*si ) in SOS
-    sosconstr(1) = -(gradV1*fK1 + L2 + s(1)*(gamma-V1) - si(1)*phi) >= 0;
+    sosconstr{1} = -(gradV1*fK1 + L2 + s(1)*(gamma-V1) - si(1)*phi) >= 0;
     % -( pb + (g-p2)*s + (phi-l)*si ) in SOS
-    sosconstr(2) = -(gradV2*fK2 + L2 + s(2)*(gamma-V2) + si(2)*(phi-L2)) >= 0;
+    sosconstr{2} = -(gradV2*fK2 + L2 + s(2)*(gamma-V2) + si(2)*(phi-L2)) >= 0;
     
     % {x: V1(x) <= g} intersects {x: phi(x) <= 0} is contained in {x: c(x) <= 0}
-    sosconstr(3) = -(cK + sg(1)*(gamma - V1) - sj(1)*phi) >= 0;
+    sosconstr{3} = -(cK + sg(1)*(gamma - V1) - sj(:,1)*phi) >= 0;
     % {x: V2(x) <= g} intersects {x: phi(x) > 0} is contained in {x: c(x) <= 0}
-    sosconstr(4) = -(cK + sg(2)*(gamma - V2) + sj(2)*(phi-L2)) >= 0;
+    sosconstr{4} = -(cK + sg(2)*(gamma - V2) + sj(:,2)*(phi-L2)) >= 0;
     
     % solve problem
+    sosconstr = vertcat(sosconstr{:});
     [info,dopt] = sosopt(sosconstr,x,opts);
     
 end

--- a/pwroaest.m
+++ b/pwroaest.m
@@ -124,7 +124,7 @@ for i1=1:NstepBis
     elseif isempty(zK)
         % nothing to do
         
-    elseif gmin <= gpre
+    elseif gpre <= gmin
         % local K-V-s problem
         K = roaKstep(f1,c,p,x,u,zK,V{1},b,g,s0,s,sg,L1,L2,sopts);
         if isempty(K)
@@ -137,7 +137,7 @@ for i1=1:NstepBis
         K = pwroaKstep(f1,f2,phi,c,p,x,u,zK,V,[b1 b2],g,s0,s,si,sg,sj,L1,L2,roaopts);
         if isempty(K)
             if strcmp(display,'on')
-                fprintf('K-step infeasible at iteration = %d\n',i1);
+                fprintf('common K-step infeasible at iteration = %d\n',i1);
             end
             break;
         end

--- a/pwroaest.m
+++ b/pwroaest.m
@@ -47,7 +47,7 @@ function [beta,V,gamma,varargout] = pwroaest(f1,f2,phi,x,roaopts)
 % * Author:     Torbjoern Cunis
 % * Email:      <mailto:torbjoern.cunis@onera.fr>
 % * Created:    2018-05-22
-% * Changed:    2018-05-23
+% * Changed:    2019-01-15
 %
 %% See also
 %
@@ -147,7 +147,7 @@ for i1=1:NstepBis
     if ~isempty(u)
         fK1 = subs(f1,u,K);
         fK2 = subs(f2,u,K);
-        cK  = polynomial(subs(c, u,K));
+        cK  = polynomial(subs(c,u,K));
     else
         fK1 = f1;
         fK2 = f2;
@@ -173,7 +173,7 @@ for i1=1:NstepBis
             [V{:}]=pwlinstab(fK1,fK2,phi,x);
         end
         
-    elseif g <= gmin
+    elseif gpre <= gmin
         % local V-s problem
         [V{1},~] = roavstep(fK1,p,x,zV{1},b,g,s0,s,L1,L2,sopts);
         if isempty(V{1})
@@ -185,7 +185,7 @@ for i1=1:NstepBis
             V{2} = V{1};
         end
     else
-        [V{:}] = pwroavstep(fK1,fK2,phi,p,x,zV,[b1 b2],g,s0,s,si,sj,L1,L2,roaopts);
+        [V{:}] = pwroavstep(fK1,fK2,phi,p,x,zV,[b1 b2],g,s0,s,si,[0 0],L1,L2,roaopts);
         if isempty(V{1})
             if strcmp(display,'on') && length(V) == 1
                 fprintf('common V-step infeasible at iteration = %d\n',i1);
@@ -370,7 +370,7 @@ for i1=1:NstepBis
             break;
         end
         
-        gc2 = gcons(2);
+        gc2 = gcons(1);
         
         if strcmp(debug,'on')
             fprintf('debug: gstb = %4.6f \t gc1 = %4.6f \t gc2 = %4.6f\n', gstb, gc1, gc2);

--- a/pwroaest.m
+++ b/pwroaest.m
@@ -126,7 +126,7 @@ for i1=1:NstepBis
         
     elseif gmin <= gpre
         % local K-V-s problem
-        K = roaKstep(f1,p,c,x,u,zK,V{1},b,g,s0,s,sg,L1,L2,sopts);
+        K = roaKstep(f1,c,p,x,u,zK,V{1},b,g,s0,s,sg,L1,L2,sopts);
         if isempty(K)
             if strcmp(display,'on')
                 fprintf('local K-step infeasible at iteration = %d\n',i1);
@@ -134,10 +134,10 @@ for i1=1:NstepBis
             break;
         end
     else
-        K = pwroaKstep(f1,f2,phi,p,c,x,u,zK,V,[b1 b2],g,s0,s,si,sg,sj,L1,L2,roaopts);
+        K = pwroaKstep(f1,f2,phi,c,p,x,u,zK,V,[b1 b2],g,s0,s,si,sg,sj,L1,L2,roaopts);
         if isempty(K)
             if strcmp(display,'on')
-                fprintf('common K-step infeasible at iteration = %d\n',i1);
+                fprintf('K-step infeasible at iteration = %d\n',i1);
             end
             break;
         end

--- a/pwroaest.m
+++ b/pwroaest.m
@@ -88,6 +88,8 @@ if ~strcmp(log,'none') && ~exist(logpath{1},'file')
     elseif ~success
         error(info)
     end
+elseif exist(logpath{1},'file')
+    delete([logpath{1} '/*.mat']);
 end
 
 % Vdeg = zV.maxdeg;

--- a/pwroaest.m
+++ b/pwroaest.m
@@ -1,4 +1,4 @@
-function [beta,V,gamma,varargout] = pwroaest(f1,f2,phi,x,roaopts)
+function [beta,V,gamma,K,iter] = pwroaest(f1,f2,phi,x,roaopts)
 % Estimates lower bound of piece-wise region of attraction.
 %
 %% Usage & description
@@ -175,7 +175,7 @@ for i1=1:NstepBis
         
     elseif gpre <= gmin
         % local V-s problem
-        [V{1},~] = roavstep(fK1,p,x,zV{1},b,g,s0,s,L1,L2,sopts);
+        [V{1},~] = conroavstep(fK1,cK,p,x,zV{1},b,g,s0,s,sg,L1,L2,sopts);
         if isempty(V{1})
             if strcmp(display,'on')
                 fprintf('local V-step infeasible at iteration = %d\n',i1);
@@ -185,7 +185,7 @@ for i1=1:NstepBis
             V{2} = V{1};
         end
     else
-        [V{:}] = pwroavstep(fK1,fK2,phi,p,x,zV,[b1 b2],g,s0,s,si,[0 0],L1,L2,roaopts);
+        [V{:}] = pwroavstep(fK1,fK2,phi,cK,p,x,zV,[b1 b2],g,s0,s,si,sg,sj,L1,L2,roaopts);
         if isempty(V{1})
             if strcmp(display,'on') && length(V) == 1
                 fprintf('common V-step infeasible at iteration = %d\n',i1);
@@ -500,16 +500,9 @@ iter(biscount+1:end) = [];
 result = iter(idx);
 beta  = result.beta;
 V     = result.V;
-s0    = result.s0;
-s2    = result.s;
-si    = result.si;
+K     = result.K;
 gamma = result.gamma;   % handle empty gamma value
 
-if nargout <= 4
-    varargout = {iter};
-else
-    varargout = {s0,s2,si,iter};
-end
 
 if any(strcmp(log,{'step' 'result'}))
     save([logpath{:} 'result'], 'iter');

--- a/pwroaoptions.m
+++ b/pwroaoptions.m
@@ -50,6 +50,10 @@ properties
     %Vin -- inherited from ROAOPTIONS
     zVi;
     Vi0;
+    %zK  -- inherited from CONROAOPTIONS
+    %Kin -- inherited from CONROAOPTIONS
+    zKi;
+    Ki0;
     
     %display -- inherited from ROAOPTIONS
     debug = 'off';
@@ -92,8 +96,16 @@ methods
             opt.zgi = opt.zg;
         end
         
+        if isempty(opt.zKi)
+            opt.zKi = opt.zK;
+        end
+        
         if isempty(opt.Vi0) && ~isempty(opt.Vin)
             opt.Vi0 = {opt.Vin};
+        end
+        
+        if isempty(opt.Ki0) && ~isempty(opt.Kin)
+            opt.Ki0 = {opt.Kin};
         end
         
 %         if isempty(opt.gammacheck) && length(opt.zVi) > 1
@@ -109,7 +121,7 @@ methods
         end
     end
     
-    % Set: zV
+    % Set: zVi
     function opt = set.zVi(opt,value)
         if ismonom(value)
             opt.zVi = {value};
@@ -122,13 +134,34 @@ methods
         opt.zV = opt.zVi{1};
     end
 
+    % Set: zKi
+    function opt = set.zKi(opt,value)
+        if ismonom(value)
+            opt.zKi = {value};
+        elseif iscell(value) && ~isempty(value) && ismonom(value{1})
+            opt.zKi = value;
+        else
+            error('zKi must be a non-empty cell of vectors of monomials.');
+        end
+        
+        opt.zK = opt.zKi{1};
+    end
 
-    % Set: Vin
+    % Set: Vi0
     function opt = set.Vi0(opt,value)
         if iscell(value) && ~isempty(value) && isa(value{1},'polynomial')
             opt.Vi0 = value;
         else
             error('Lyapunov functions must be polynomials.');
+        end
+    end
+    
+    % Set: Ki0
+    function opt = set.Ki0(opt,value)
+        if iscell(value) && ~isempty(value) && isa(value{1},'polynomial')
+            opt.Ki0 = value;
+        else
+            error('Controllers must be polynomials.');
         end
     end
     

--- a/pwroaoptions.m
+++ b/pwroaoptions.m
@@ -136,7 +136,7 @@ methods
 
     % Set: zKi
     function opt = set.zKi(opt,value)
-        if ismonom(value)
+        if isempty(value) || ismonom(value)
             opt.zKi = {value};
         elseif iscell(value) && ~isempty(value) && ismonom(value{1})
             opt.zKi = value;

--- a/pwroaoptions.m
+++ b/pwroaoptions.m
@@ -1,4 +1,4 @@
-classdef pwroaoptions < roaoptions
+classdef pwroaoptions < conroaoptions
 % Options for piecewise ROA estimation.
 %
 %% Usage & description
@@ -55,7 +55,7 @@ end
 
 methods
     function opt = pwroaoptions(f1, f2, phi, x, varargin)
-        opt@roaoptions(f1, x, varargin{:});
+        opt@conroaoptions(f1, x, varargin{:});
         
         opt.f1  = f1;
         opt.f2  = f2;

--- a/pwroaoptions.m
+++ b/pwroaoptions.m
@@ -49,6 +49,8 @@ properties
     
     %display -- inherited from ROAOPTIONS
     debug = 'off';
+    log   = 'none';
+    logpath;
     
     gammacheck = 'none';
 end
@@ -93,6 +95,10 @@ methods
 %         elseif isempty(opt.gammacheck)
 %             opt.gammacheck = 'none';
 %         end
+
+        if isempty(opt.logpath) && ~strcmp(opt.log,'none')
+            opt.logpath = 'data/';
+        end
     end
     
     % Set: zV
@@ -187,6 +193,27 @@ methods
         
         % if not error
         opt.debug = value;
+    end
+    
+    % Set: log
+    function opt = set.log(opt,value)
+        AllowableVal = {'none' 'step' 'result'};
+        if ischar(value) && any(strcmp(value,AllowableVal))
+            opt.log = value;
+        else
+            error('log must be one of ''none,'' ''step,'' or ''result''.');
+        end
+    end
+    
+    % Set: logpath
+    function opt = set.logpath(opt,value)
+        if ischar(value)
+            opt.logpath = {value};
+        elseif iscell(value) && ~isempty(value) && ischar(value{1})
+            opt.logpath = value;
+        else
+            error('log path must be character array.');
+        end
     end
 end
 

--- a/pwroaoptions.m
+++ b/pwroaoptions.m
@@ -39,9 +39,13 @@ properties
     f2;
     phi;
     xi;
+    %z1 -- inherited from ROAOPTIONS
+    %z2 -- inherited from ROAOPTIONS
+    %zg -- inherited from CONROAOPTIONS
     zi;
     z1i;
     z2i;
+    zgi;
     %zV  -- inherited from ROAOPTIONS
     %Vin -- inherited from ROAOPTIONS
     zVi;
@@ -82,6 +86,10 @@ methods
         
         if isempty(opt.z2i)
             opt.z2i = opt.z2;
+        end
+        
+        if isempty(opt.zgi)
+            opt.zgi = opt.zg;
         end
         
         if isempty(opt.Vi0) && ~isempty(opt.Vin)
@@ -126,7 +134,7 @@ methods
     
     % Set: z1i
     function opt = set.z1i(opt,value)
-        if  ismonom(value) || isa(value,'double')
+        if ismonom(value) || isa(value,'double')
             opt.z1i = {value};
         elseif iscell(value) && ~isempty(value) && ismonom(value{1}) && ~isa(value{1},'double')
             opt.z1i = value;
@@ -139,7 +147,7 @@ methods
     
     % Set: z2i
     function opt = set.z2i(opt,value)
-        if  ismonom(value) && ~isa(value,'double')
+        if ismonom(value) && ~isa(value,'double')
             opt.z2i = {value};
         elseif iscell(value) && ~isempty(value) && ismonom(value{1}) && ~isa(value{1},'double')
             opt.z2i = value;
@@ -150,9 +158,24 @@ methods
         opt.z2 = opt.z2i{1};
     end 
     
+    % Set: zgi
+    function opt = set.zgi(opt,value)
+        if isempty(value)
+            opt.zgi = cell(1,1);
+        elseif ismonom(value) && ~isa(value,'double')
+            opt.zgi = {value};
+        elseif iscell(value) && ~isempty(value) && ismonom(value{1}) && ~isa(value{1},'double')
+            opt.zgi = value;
+        else
+            error('Multiplier of piecewise constraint step must be a monomial and non-constant.');
+        end
+        
+        opt.zg = opt.zgi{1};
+    end
+    
     % Set: zi
     function opt = set.zi(opt,value)
-        if  ismonom(value) && ~isa(value,'double')
+        if ismonom(value) && ~isa(value,'double')
             opt.zi = {value};
         elseif iscell(value) && ~isempty(value) && ismonom(value{1}) && ~isa(value{1},'double')
             opt.zi = value;
@@ -163,7 +186,7 @@ methods
     
     % Set: xi
     function opt = set.xi(opt,value)
-        if  ispvar(value)
+        if ispvar(value)
             opt.xi = value;
         else
             error('State vector for boundary condition must be polynomial variables.');

--- a/pwroaoptions.m
+++ b/pwroaoptions.m
@@ -25,7 +25,7 @@ classdef pwroaoptions < conroaoptions
 % * Author:     Torbjoern Cunis
 % * Email:      <mailto:torbjoern.cunis@onera.fr>
 % * Created:    2018-05-22
-% * Changed:    2018-09-09
+% * Changed:    2019-10-28
 %
 %% See also
 %
@@ -57,8 +57,6 @@ properties
     
     %display -- inherited from ROAOPTIONS
     debug = 'off';
-    log   = 'none';
-    logpath;
     
     gammacheck = 'none';
 end
@@ -249,28 +247,7 @@ methods
         
         % if not error
         opt.debug = value;
-    end
-    
-    % Set: log
-    function opt = set.log(opt,value)
-        AllowableVal = {'none' 'step' 'result'};
-        if ischar(value) && any(strcmp(value,AllowableVal))
-            opt.log = value;
-        else
-            error('log must be one of ''none,'' ''step,'' or ''result''.');
-        end
-    end
-    
-    % Set: logpath
-    function opt = set.logpath(opt,value)
-        if ischar(value)
-            opt.logpath = {value};
-        elseif iscell(value) && ~isempty(value) && ischar(value{1})
-            opt.logpath = value;
-        else
-            error('log path must be character array.');
-        end
-    end
+    end    
 end
 
 end

--- a/pwroavstep.m
+++ b/pwroavstep.m
@@ -65,25 +65,26 @@ if length(z) == 1
     [V,c] = polydecvar('c',z{1});
 
     %% Common V-s feasibility problem
-    sosconstr = polyconstr;
+    sosconstr = cell(5,1);
 
     % V-L1 in SOS
-    sosconstr(1) = V >= L1;
+    sosconstr{1} = V >= L1;
 
     % {x: p(x) <= b} is contained in {x: V(x) <= g}
-    sosconstr(2) = -((V-gamma) + s0*(beta-p)) >= 0;
+    sosconstr{2} = -((V-gamma) + s0*(beta-p)) >= 0;
 
     % {x: V(x) <= g} is contained in {x: grad(V)*f < 0}
     gradV = jacobian(V,x);
     % -( pa + (g-p2)*s - phi*si ) in SOS
-    sosconstr(3) = -(gradV*f1 + L2 + s(1)*(gamma-V) - si(1)*phi) >= 0;
+    sosconstr{3} = -(gradV*f1 + L2 + s(1)*(gamma-V) - si(1)*phi) >= 0;
     % -( pb + (g-p2)*s + (phi-l)*si ) in SOS
-    sosconstr(4) = -(gradV*f2 + L2 + s(2)*(gamma-V) + si(2)*(phi-L2)) >= 0;
+    sosconstr{4} = -(gradV*f2 + L2 + s(2)*(gamma-V) + si(2)*(phi-L2)) >= 0;
     
     % {x: V(x) <= g} is contained in {x: c(x) <= 0}
-    sosconstr(5) = -(con + sg*(gamma-V)) >= 0;
+    sosconstr{5} = -(con + sg*(gamma-V)) >= 0;
 
     % solve problem
+    sosconstr = vertcat(sosconstr{:});
     [info,dopt] = sosopt(sosconstr,x,opts);
 
     % output
@@ -107,41 +108,42 @@ else
     ];
     
     %% Multiple V-s feasibility problem
-    sosconstr = polyconstr;
+    sosconstr = cell(14,1);
     
     % Vi-L1 in SOS
-    sosconstr(1) = V1 >= L1;
-    sosconstr(2) = V2 >= L1;
+    sosconstr{1} = V1 >= L1;
+    sosconstr{2} = V2 >= L1;
     
     % {x: p(x) <= b} intersects {x: phi(x) <= 0} is contained in {x: V1(x) <= g}
-    sosconstr(3) = -((V1-gamma) + s0(1)*(beta(1)-p)) >= 0;
+    sosconstr{3} = -((V1-gamma) + s0(1)*(beta(1)-p)) >= 0;
     % {x: p(x) <= b} intersects {x: phi(x) > 0} is contained in {x: V2(x) <= g}
-    sosconstr(4) = -((V2-gamma) + s0(2)*(beta(2)-p)) >= 0;
+    sosconstr{4} = -((V2-gamma) + s0(2)*(beta(2)-p)) >= 0;
     
     % {x: V(x) <= g} is contained in {x: grad(V)*f < 0}
     gradV1 = jacobian(V1,x);
     gradV2 = jacobian(V2,x);
     % -( pa + (g-p2)*s - phi*si ) in SOS
-    sosconstr(5) = -(gradV1*f1 + L2 + s(1)*(gamma-V1) - si(1)*phi) >= 0;
+    sosconstr{5} = -(gradV1*f1 + L2 + s(1)*(gamma-V1) - si(1)*phi) >= 0;
     % -( pb + (g-p2)*s + (phi-l)*si ) in SOS
-    sosconstr(6) = -(gradV2*f2 + L2 + s(2)*(gamma-V2) + si(2)*(phi-L2)) >= 0;
+    sosconstr{6} = -(gradV2*f2 + L2 + s(2)*(gamma-V2) + si(2)*(phi-L2)) >= 0;
     
     % {x: V1(x) <= g} intersects {x: phi(x) <= 0} is contained in {x: c(x) <= 0}
-    sosconstr(7) = -(con + sg(1)*(gamma - V1) - sj(1)*phi) >= 0;
+    sosconstr{7} = -(con + sg(1)*(gamma - V1) - sj(1)*phi) >= 0;
     % {x: V2(x) <= g} intersects {x: phi(x) > 0} is contained in {x: c(x) <= 0}
-    sosconstr(8) = -(con + sg(2)*(gamma - V2) + sj(2)*(phi-L2)) >= 0;
+    sosconstr{8} = -(con + sg(2)*(gamma - V2) + sj(2)*(phi-L2)) >= 0;
     
     % {x: phi(x) <= 0} intersects {x: phi(x) >= 0} is contained in {x: V1(x) <= V2(x)}
-    sosconstr(9) = -((V1-V2) + ri(1)*phi - ri(2)*phi) >= 0;
+    sosconstr{9} = -((V1-V2) + ri(1)*phi - ri(2)*phi) >= 0;
     % {x: phi(x) <= 0} intersects {x: phi(x) >= 0} is contained in {x: V1(x) >= V2(x)}
-    sosconstr(10) = -((V2-V1) + ri(3)*phi - ri(4)*phi) >= 0;
+    sosconstr{10} = -((V2-V1) + ri(3)*phi - ri(4)*phi) >= 0;
     
-    sosconstr(11) = ri(1) >= 0;
-    sosconstr(12) = ri(2) >= 0;
-    sosconstr(13) = ri(3) >= 0;
-    sosconstr(14) = ri(4) >= 0;
+    sosconstr{11} = ri(1) >= 0;
+    sosconstr{12} = ri(2) >= 0;
+    sosconstr{13} = ri(3) >= 0;
+    sosconstr{14} = ri(4) >= 0;
     
     % solve problem
+    sosconstr = vertcat(sosconstr{:});
     [info,dopt] = sosopt(sosconstr,x,opts);
 
     % output

--- a/pwroavstep.m
+++ b/pwroavstep.m
@@ -129,7 +129,7 @@ else
     % {x: V1(x) <= g} intersects {x: phi(x) <= 0} is contained in {x: c(x) <= 0}
     sosconstr(7) = -(con + sg(1)*(gamma - V1) - sj(1)*phi) >= 0;
     % {x: V2(x) <= g} intersects {x: phi(x) > 0} is contained in {x: c(x) <= 0}
-    sosconstr(8) = -(con + sg(2)*(gamma - V1) + sj(2)*(phi-L2)) >= 0;
+    sosconstr(8) = -(con + sg(2)*(gamma - V2) + sj(2)*(phi-L2)) >= 0;
     
     % {x: phi(x) <= 0} intersects {x: phi(x) >= 0} is contained in {x: V1(x) <= V2(x)}
     sosconstr(9) = -((V1-V2) + ri(1)*phi - ri(2)*phi) >= 0;

--- a/pwroavstep.m
+++ b/pwroavstep.m
@@ -128,9 +128,9 @@ else
     sosconstr{6} = -(gradV2*f2 + L2 + s(2)*(gamma-V2) + si(2)*(phi-L2)) >= 0;
     
     % {x: V1(x) <= g} intersects {x: phi(x) <= 0} is contained in {x: c(x) <= 0}
-    sosconstr{7} = -(con + sg(1)*(gamma - V1) - sj(1)*phi) >= 0;
+    sosconstr{7} = -(con + sg(1)*(gamma - V1) - sj(:,1)*phi) >= 0;
     % {x: V2(x) <= g} intersects {x: phi(x) > 0} is contained in {x: c(x) <= 0}
-    sosconstr{8} = -(con + sg(2)*(gamma - V2) + sj(2)*(phi-L2)) >= 0;
+    sosconstr{8} = -(con + sg(2)*(gamma - V2) + sj(:,2)*(phi-L2)) >= 0;
     
     % {x: phi(x) <= 0} intersects {x: phi(x) >= 0} is contained in {x: V1(x) <= V2(x)}
     sosconstr{9} = -((V1-V2) + ri(1)*phi - ri(2)*phi) >= 0;

--- a/pwroavstep.m
+++ b/pwroavstep.m
@@ -80,8 +80,22 @@ if length(z) == 1
     % -( pb + (g-p2)*s + (phi-l)*si ) in SOS
     sosconstr{4} = -(gradV*f2 + L2 + s(2)*(gamma-V) + si(2)*(phi-L2)) >= 0;
     
-    % {x: V(x) <= g} is contained in {x: c(x) <= 0}
-    sosconstr{5} = -(con + sg*(gamma-V)) >= 0;
+    if length(con) == 1
+        % polynomial control constraint
+        con0 = con{1};
+        
+        % {x: V(x) <= g} is contained in {x: c(x) <= 0}
+        sosconstr{5} = -(con0 + sg*(gamma-V)) >= 0;
+    else
+        % piecewise control constraint
+        con1 = con{1};
+        con2 = con{2};
+        
+        % {x: V(x) <= g} intersects {x: phi(x) <= 0} is contained in {x: c1(x) <= 0}
+        sosconstr{7} = -(con1 + sg(1)*(gamma - V) - sj(:,1)*phi) >= 0;
+        % {x: V(x) <= g} intersects {x: phi(x) > 0} is contained in {x: c2(x) <= 0}
+        sosconstr{8} = -(con2 + sg(2)*(gamma - V) + sj(:,2)*(phi-L2)) >= 0;
+    end
 
     % solve problem
     sosconstr = vertcat(sosconstr{:});
@@ -99,6 +113,10 @@ else
     % Lyapunov decision variables
     [V1,c1] = polydecvar('c1',z{1});
     [V2,c2] = polydecvar('c2',z{2});
+    
+    % control constraints
+    con1 = con{1};
+    con2 = con{end};
     
     % continuity decision variables
     ri = [ sosdecvar('ci1',zi1)
@@ -128,9 +146,9 @@ else
     sosconstr{6} = -(gradV2*f2 + L2 + s(2)*(gamma-V2) + si(2)*(phi-L2)) >= 0;
     
     % {x: V1(x) <= g} intersects {x: phi(x) <= 0} is contained in {x: c(x) <= 0}
-    sosconstr{7} = -(con + sg(1)*(gamma - V1) - sj(:,1)*phi) >= 0;
+    sosconstr{7} = -(con1 + sg(1)*(gamma - V1) - sj(:,1)*phi) >= 0;
     % {x: V2(x) <= g} intersects {x: phi(x) > 0} is contained in {x: c(x) <= 0}
-    sosconstr{8} = -(con + sg(2)*(gamma - V2) + sj(:,2)*(phi-L2)) >= 0;
+    sosconstr{8} = -(con2 + sg(2)*(gamma - V2) + sj(:,2)*(phi-L2)) >= 0;
     
     % {x: phi(x) <= 0} intersects {x: phi(x) >= 0} is contained in {x: V1(x) <= V2(x)}
     sosconstr{9} = -((V1-V2) + ri(1)*phi - ri(2)*phi) >= 0;

--- a/roaKstep.m
+++ b/roaKstep.m
@@ -1,0 +1,6 @@
+function [K,cK] = roaKstep(f,p,c,x,u,zK,V,beta,gamma,s1,s2,sg,L1,L2,sopts)
+% Solves the K-V-s step of the constraint ROA iteration.
+
+error('K-V-s step not implemented yet.')
+
+end

--- a/roaKstep.m
+++ b/roaKstep.m
@@ -60,16 +60,17 @@ fK = subs(f,u,K);
 cK = subs(con,u,K);
 
 %% Constrained control feasibility problem
-sosconstr = polyconstr;
+sosconstr = cell(2,1);
 
 % {x: V(x) <= g} is contained in {x: grad(V)*fK < 0}
 Vdot = jacobian(V,x)*fK;
-sosconstr(1) = Vdot <= -L2 + s2*(V-gamma);
+sosconstr{1} = Vdot <= -L2 + s2*(V-gamma);
 
 % {x: V(x) <= g} is contained in {x: cK(x) <= 0}
-sosconstr(2) = -(cK + sg*(gamma-V)) >= 0;
+sosconstr{2} = -(cK + sg*(gamma-V)) >= 0;
 
 % solve feasibility problem
+sosconstr = vertcat(sosconstr{:});
 [info,dopt] = sosopt(sosconstr,x,opts);
 
 %% Output

--- a/roaKstep.m
+++ b/roaKstep.m
@@ -1,6 +1,84 @@
-function [K,cK] = roaKstep(f,p,c,x,u,zK,V,beta,gamma,s1,s2,sg,L1,L2,sopts)
+function [K,c] = roaKstep(f,con,~,x,u,z,V,~,gamma,~,s2,sg,~,L2,opts)
 % Solves the K-V-s step of the constraint ROA iteration.
+%
+%% Usage & description
+%
+%   [K,c] = conroaKstep(f,con,p,x,u,z,V,beta,gamma,s1,s2,sg)
+%   [...] = conroaKstep(...,L1,L2,opts)
+%
+% Solves for a control function K which satisfies the SOS constraints 
+% while holding all other variables fixed.
+%
+% Inputs:
+%       -f:   polynomial vector field
+%       -con: constraint function (scalar polynomial)
+%       -p:   shape function (scalar polynomial)
+%       -x:   state-space vector as PVAR
+%       -u:   input vector as PVAR
+%       -z:   Nz-by-1 column vector of monomials; specifies the control
+%             function decision variable in the vector form K(x) = c'*z(x).
+%       -V:   Lyapunov function (scalar polynomial)
+%       -beta:     level set of shape function
+%       -gamma:    level set of Lyapunov function
+%       -s1,s2,sg: set containment multipliers
+%       -L1:  epsilon 1 (double or scalar field); enforces strict positive 
+%             definiteness of the Lyapunov function.
+%       -L2:  epsilon 2 (double or scalar field); enforces strict negative 
+%             definiteness of the Lyapunov gradient.
+%       -opts:     SOS options structure;  see SOSOPTIONS.
+%
+% Outputs:
+%       -K: control function satisfying the SOS constraints; will be empty
+%           if no feasible solution is found.
+%       -c: Nz-by-1 vector of coefficients of the returned control
+%           function.
+%
+%% About
+%
+% * Author:     Torbjoern Cunis
+% * Email:      <mailto:torbjoern.cunis@onera.fr>
+% * Created:    2019-01-24
+% * Changed:    2019-01-24
+%
+%% See also
+%
+% See PWROAEST, CONROAVSTEP
+%%
 
-error('K-V-s step not implemented yet.')
+if isempty(opts)
+    opts = sosoptions;
+end
+
+
+% control decision variable
+[K,c] = polydecvar('c',z);
+
+% control system
+fK = subs(f,u,K);
+
+% control input constraint
+cK = subs(con,u,K);
+
+%% Constrained control feasibility problem
+sosconstr = polyconstr;
+
+% {x: V(x) <= g} is contained in {x: grad(V)*fK < 0}
+Vdot = jacobian(V,x)*fK;
+sosconstr(1) = Vdot <= -L2 + s2*(V-gamma);
+
+% {x: V(x) <= g} is contained in {x: cK(x) <= 0}
+sosconstr(2) = -(cK + sg*(gamma-V)) >= 0;
+
+% solve feasibility problem
+[info,dopt] = sosopt(sosconstr,x,opts);
+
+%% Output
+if info.feas
+    K = subs(K,dopt);
+    c = subs(c,dopt);
+else
+    K=[];
+    c=[];
+end
 
 end

--- a/roaload.m
+++ b/roaload.m
@@ -1,4 +1,4 @@
-function [beta,V,gamma,iter] = roaload(varargin)
+function [beta,V,gamma,K,iter] = roaload(varargin)
 % Loads stored ROA estimation results.
 %
 %% Usage & description
@@ -82,5 +82,6 @@ iter  = S.iter;
 beta  = S.beta;
 V     = S.V;
 gamma = S.gamma;
+K     = S.K;
 
 end

--- a/roaload.m
+++ b/roaload.m
@@ -1,0 +1,86 @@
+function [beta,V,gamma,iter] = roaload(varargin)
+% Loads stored ROA estimation results.
+%
+%% Usage & description
+%
+%   [beta,V,gamma,...] = roaload(filename,path)
+%   [...] = roaload(filename,ropts)
+%   [...] = roaload(iter,ropts)
+%   [...] = roaload(ropts)
+%
+% Inputs:
+%   - path:     file path (absolute/relative)
+%   - filename: file in log folder (see ropts)
+%   - iter:     iteration in log folder (see ropts)
+%   - ropts:    options for ROA estimation; used to determine log folder.
+%               See PWROAOPTIONS for defaults.
+%
+%   If no log file is specified, the final result is loaded.
+%
+% Outputs:
+%   See PWROAEST for output variables.
+%
+%% About
+%
+% * Author:     Torbjoern Cunis
+% * Email:      <mailto:torbjoern.cunis@onera.fr>
+% * Created:    2019-01-21
+% * Changed:    2019-01-21
+%
+%% See also
+%
+% See PWROAOPTIONS, PWROAEST
+%%
+
+for i=1:nargin
+    arg = varargin{i};
+    
+    if ~exist('filename','var') && ischar(arg) && ~exist('iter','var')
+        filename = arg;
+    elseif ~exist('path','var') && ischar(arg)
+        path = arg;
+    elseif ~exist('iter','var') && isnumeric(arg)
+        iter = arg;
+    elseif ~exist('ropts','var') && isa(arg,'roaoptions')
+        ropts = arg;
+    end
+end
+
+if ~exist('filename','var'),    filename = [];  end
+if ~exist('path','var'),        path = [];      end
+if ~exist('iter','var'),        iter = [];      end
+if ~exist('ropts','var'),       ropts = [];     end
+
+
+if ~isempty(path)
+    if ~iscell(path)
+        path = {path};
+    end
+elseif ~isempty(ropts)
+    path = ropts.logpath;
+elseif ~isempty(filename)
+    path = '.';
+else
+    ropts = pwroaoptions(polynomial, polynomial, polynomial, pvar('x'));
+    path = ropts.logpath;
+end
+
+if ~isempty(filename)
+    [~,~,ext] = fileparts(filename);
+    if isempty(ext)
+        filename = [filename '.mat'];
+    end
+elseif ~isempty(iter)
+    filename = sprintf('iter%d.mat',iter);
+else
+    filename = 'result.mat';
+end
+
+S = load([path{:} filename], '-mat');
+
+iter  = S.iter;
+beta  = S.beta;
+V     = S.V;
+gamma = S.gamma;
+
+end


### PR DESCRIPTION
This pull request extends the region of attraction estimation to take into account state constraints, i.e.,
```
    ci(x) ≤ 0 if V(x) ≤ γ
```
where `ci(⋅)` is a (polynomial) constraint scalar field in `x`.

It further introduces the synthesis of a feedback policy `K(⋅)` under state and input constraints for systems of the form `xdot = f(x,u)`,
```
    grad V(x)⋅f(x,K(x)) < 0 if V(x) ≤ γ
    ci(x) ≤ 0 if V(x) ≤ γ
    dj(K(x)) ≤ 0 if V(x) ≤ γ
```
where `ci(⋅)` and `dj(⋅)` are (polynomial) constraint scalar fields in `x` and `u`, provided that `f` and `dj` are affine in `u`.